### PR TITLE
Fixed formatting errors in Installing CLI section

### DIFF
--- a/modules/ROOT/pages/proc_checking-pipeline-and-application-status.adoc
+++ b/modules/ROOT/pages/proc_checking-pipeline-and-application-status.adoc
@@ -13,7 +13,7 @@ You can examine the logs for `PipelineRuns` to verify its status.
 . Check the `PipelineRun` logs as it runs using the `tkn pipeline logs` command, which interactively allows you to chose the required pipelinerun and inspect the logs:
 +
 ----
-$ tkn pipeline logs-f
+$ tkn pipeline logs -f
 ? Select pipeline : petclinic-deploy-pipeline
 ? Select pipelinerun : petclinic-deploy-pipeline-run-tsv92 started 39 seconds ago
 

--- a/modules/ROOT/pages/proc_installing_cli.adoc
+++ b/modules/ROOT/pages/proc_installing_cli.adoc
@@ -7,44 +7,51 @@ In order to interact with Tekton from a terminal, you need to install the Tekton
 
 === For macOS X
 
-.Get the `tar.xz`:
+. Get the `tar.xz`:
++
 ----
 curl -LO https://github.com/tektoncd/cli/releases/download/v0.2.2/tkn_0.2.2_Darwin_x86_64.tar.gz
 ----
 
-.Extract `tkn` to your PATH:
+. Extract `tkn` to your PATH:
++
 ----
 sudo tar xvzf tkn_0.2.2_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
 ----
 
 === For Linux AMD64
 
-.Get the `tar.xz`:
+. Get the `tar.xz`:
++
 ----
 curl -LO https://github.com/tektoncd/cli/releases/download/v0.2.2/tkn_0.2.2_Linux_x86_64.tar.gz
 ----
 
-.Extract `tkn` to your PATH:
+. Extract `tkn` to your PATH:
++
 ----
 sudo tar xvzf tkn_0.2.2_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
 ----
 
 === For Linux ARM64
 
-.Get the `tar.xz`:
+. Get the `tar.xz`:
++
 ----
 curl -LO https://github.com/tektoncd/cli/releases/download/v0.2.2/tkn_0.2.2_Linux_arm64.tar.gz
 ----
 
-.Extract `tkn` to your PATH:
+. Extract `tkn` to your PATH:
++
 ----
 sudo tar xvzf tkn_0.2.2_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
 ----
 
 == Installing with Go language
-You should have link:https://golang.org/doc/install[Go language] installed and set up your go environment correctly. 
+You should have link:https://golang.org/doc/install[Go language] installed and the go environment set up correctly.
 
-.To install Tekton CLI with Go, run:
+. To install Tekton CLI with Go, run:
++
 ----
 GO111MODULE="on" go get github.com/tektoncd/cli@v0.2.2
 ----

--- a/modules/ROOT/pages/proc_installing_cli.adoc
+++ b/modules/ROOT/pages/proc_installing_cli.adoc
@@ -50,8 +50,8 @@ sudo tar xvzf tkn_0.2.2_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
 == Installing with Go language
 You should have link:https://golang.org/doc/install[Go language] installed and the go environment set up correctly.
 
-. To install Tekton CLI with Go, run:
-+
+To install Tekton CLI with Go, run:
+
 ----
 GO111MODULE="on" go get github.com/tektoncd/cli@v0.2.2
 ----


### PR DESCRIPTION
@joaedwar @boczkowska, I have fixed the formatting errors resulting in the italicized rendering. 
Also it fixes #5  the space issue between the command and flag
Please merge and republish the docs.