### PR TITLE
Edits to Openshift Pipelines Docs Landing Page

### DIFF
--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -146,7 +146,7 @@
 <p>For more information on Tekton see the <a href="https://github.com/tektoncd">Tekton Pipelines documentation</a></p>
 </li>
 <li>
-<p>Visit our <a href="https://github.com/openshift/pipelines-docs">GitHub</a> repository to report any issues with the documentation</p>
+<p>Visit our <a href="https://github.com/openshift/pipelines-docs">GitHub</a> repository to report any issues with the OpenShift Pipelines documentation</p>
 </li>
 </ul>
 </div>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -115,24 +115,24 @@
 <article class="doc">
 <h1 class="page">OpenShift Pipelines</h1>
 <div class="paragraph">
-<p>OpenShift Pipelines are cloud-native, continuous integration and delivery solutions based on Kubernetes resources. It uses <a href="https://tekton.dev">Tekton</a> Pipelines to automate deployments across multiple platforms by abstracting away the underlying details. Tekton introduces a number of standard Custom Resource Definitions (CRDs) for defining pipelines that are portable across Kubernetes distributions.</p>
+<p>OpenShift Pipelines is a cloud-native, continuous integration and delivery (CI/CD) solution based on Kubernetes resources. It uses <a href="https://tekton.dev">Tekton</a> Pipelines to automate deployments across multiple platforms by abstracting away the underlying details. Tekton introduces a number of standard Kubernetes <a href="https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/">custom resource definitions</a> (CRDs) for defining pipelines that are portable across Kubernetes distributions.</p>
 </div>
 <div class="ulist">
 <ul>
 <li>
-<p>OpenShift Pipelines are designed for microservices and decentralized teams</p>
+<p>OpenShift Pipelines is designed for microservices and decentralized teams</p>
 </li>
 <li>
-<p>They are standard CI/CD pipeline definitions that are easy to extend and integrate with existing tools, enabling you to scale on-demand</p>
+<p>OpenShift Pipelines uses standard CI/CD pipeline definitions that are easy to extend and integrate with existing Kubernetes tools, enabling you to scale on-demand</p>
 </li>
 <li>
-<p>You can use them to build images with Kubernetes tools such as Source-to-Image (S2I), Buildah, Buildpacks, and Kaniko and are portable across any Kubernetes platform</p>
+<p>You can use OpenShift Pipelines to build images with Kubernetes tools, such as Source-to-Image (S2I), Buildah, Buildpacks, and Kaniko</p>
 </li>
 <li>
-<p>You can deploy applications to multiple platforms such as Kubernetes, Serverless, and Virtual Machines (VMs) and are portable across any Kubernetes platform</p>
+<p>It can deploy applications to multiple platforms such as Kubernetes, Serverless, and Virtual Machines (VMs)</p>
 </li>
 <li>
-<p>You can use the OpenShift Developer Console to see your Pipelines and integrate with them.</p>
+<p>You can use the OpenShift Developer Console to see create Tekton resources, view logs of pipeline runs, and manage pipelines under OpenShift project namespaces</p>
 </li>
 </ul>
 </div>
@@ -140,13 +140,13 @@
 <div class="ulist">
 <ul>
 <li>
-<p>For more details on defining pipelines, see the <a href="https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/">Custom Resources documentation</a> .</p>
+<p>For more details on defining pipelines, see the <a href="https://openshift.github.io/pipelines-docs/docs/docs/assembly_using-pipelines.html">the Using Pipelines section</a></p>
 </li>
 <li>
-<p>For more information on Tekton see the <a href="https://github.com/tektoncd">Tekton Pipelines documentation</a>.</p>
+<p>For more information on Tekton see the <a href="https://github.com/tektoncd">Tekton Pipelines documentation</a></p>
 </li>
 <li>
-<p>Visit our <a href="https://github.com/openshift/pipelines-docs">GitHub</a> repository for more information.</p>
+<p>Visit our <a href="https://github.com/openshift/pipelines-docs">GitHub</a> repository to report any issues with the documentation</p>
 </li>
 </ul>
 </div>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -132,7 +132,7 @@
 <p>It can deploy applications to multiple platforms such as Kubernetes, Serverless, and Virtual Machines (VMs)</p>
 </li>
 <li>
-<p>You can use the OpenShift Developer Console to see create Tekton resources, view logs of pipeline runs, and manage pipelines under OpenShift project namespaces</p>
+<p>You can use the OpenShift Developer Console to create Tekton resources, view logs of pipeline runs, and manage pipelines under OpenShift project namespaces</p>
 </li>
 </ul>
 </div>


### PR DESCRIPTION
This pull request makes edits to the landing page of OpenShift Pipelines Documentation. 

Key edits include:
* Making OpenShift Pipelines singular. It is a single product, so it should not be plural when describing it.
* Removing several references to how OpenShift Pipelines is portable across Kubernetes distributions. It only needs to be stated once.
* Adding link to what Kubernetes custom resource definitions are earlier.
* Replacing additional info link on CRDs with link to Using Pipelines section of documentation.
* More descriptive writing on what can be done with OpenShift web console
* I have also called out some other details in review comments