### PR TITLE
Added CRC procedure

### DIFF
--- a/modules/ROOT/pages/proc_deploying-an-application-to-openshift.adoc
+++ b/modules/ROOT/pages/proc_deploying-an-application-to-openshift.adoc
@@ -11,27 +11,21 @@
 * You have installed link:proc_installing-pipelines-operator.html[OpenShift Pipelines] using the OpenShift Pipeline Operator listed in the OpenShift OperatorHub. Once installed, it is applicable to the entire cluster.
 * You have installed the link:https://github.com/tektoncd/cli[Tekton CLI]
 * You have installed the link:https://cloud.redhat.com/openshift/install/crc/installer-provisioned?intcmp=7013a000002CtetAAC[CodeReady Containers (CRC)] - a recommended solution for quick deployment of OpenShift clusters.
-// Go to link:[CRC official documentation] to learn more.
+
 
 [discrete]
 === Procedure
 
 . Create a local CRC virtual machine:
-
-** For native hypervisors:
 +
 ----
 $ crc start
 ----
-
-** For VirtualBox, a bundle file downloaded separately and the `--vm-driver virtualbox` and `--bundle` flags are required:
 +
-----
-$ crc start --vm-driver virtualbox --bundle _path_to_system_bundle_
-----
+NOTE: If you use a hosted hypervisor, see the link:https://code-ready.github.io/crc/#starting-the-virtual-machine_gsg[CRC documentation].
 +
-NOTE: `crc start` output contains user login and password needed for logging into the cluster. 
-
+`crc start` output contains user login and password needed for logging into the cluster. 
++
 . Add the cached `oc` binary to your PATH:
 
 .. Run the crc oc-env command to print the command needed to add the cached oc binary to your PATH:

--- a/modules/ROOT/pages/proc_deploying-an-application-to-openshift.adoc
+++ b/modules/ROOT/pages/proc_deploying-an-application-to-openshift.adoc
@@ -10,9 +10,43 @@
 
 * You have installed link:proc_installing-pipelines-operator.html[OpenShift Pipelines] using the OpenShift Pipeline Operator listed in the OpenShift OperatorHub. Once installed, it is applicable to the entire cluster.
 * You have installed the link:https://github.com/tektoncd/cli[Tekton CLI]
+* You have installed the link:https://cloud.redhat.com/openshift/install/crc/installer-provisioned?intcmp=7013a000002CtetAAC[CodeReady Containers (CRC)] - a recommended solution for quick deployment of OpenShift clusters.
+// Go to link:[CRC official documentation] to learn more.
 
 [discrete]
 === Procedure
+
+. Create a local CRC virtual machine:
+
+** For native hypervisors:
++
+----
+$ crc start
+----
+
+** For VirtualBox, a bundle file downloaded separately and the `--vm-driver virtualbox` and `--bundle` flags are required:
++
+----
+$ crc start --vm-driver virtualbox --bundle _path_to_system_bundle_
+----
++
+NOTE: `crc start` output contains user login and password needed for logging into the cluster. 
+
+. Add the cached `oc` binary to your PATH:
+
+.. Run the crc oc-env command to print the command needed to add the cached oc binary to your PATH:
++
+----
+$ crc oc-env
+----
+
+.. Run the printed command.
+
+. Log into the OpenShift cluster with the provided login and password:
++
+----
+$ oc login -u <login> -p <password> https://api.crc.testing:6443
+----
 
 . Create a project for the sample application:
 +


### PR DESCRIPTION
Hi guys!
I am debating right now a few points:

1. Whether we should have a separate module for `CRC`.
2. Should I reword it so it would be clear that `CRC` is the **recommended supported** solution for quick deployment of clusters and that Pipelines can be used on any properly set up and running OpenShift cluster.
3. That `VirtualBox` line... It is not our product (it is made by Oracle...) but `CRC` docs do mention it since the commands needs to be run with those flags if the user has VistualBox.