### PR TITLE
tkn CLI install changes

### DIFF
--- a/modules/ROOT/pages/installing-tkn.adoc
+++ b/modules/ROOT/pages/installing-tkn.adoc
@@ -1,0 +1,18 @@
+[id='installing-tkn']
+= Installing tkn
+include::modules/common-attributes.adoc[]
+include::modules/openshift-pipelines-attributes.adoc[]
+:context: installing-tkn
+
+toc::[]
+
+The following section describes how to install 'tkn' on different platforms.
+
+// Install tkn on Linux
+include::op-installing-tkn-on-linux.adoc[leveloffset=+1]
+
+//Install tkn on Windows
+include::op-installing-tkn-on-windows.adoc[leveloffset=+1]
+
+//Install tkn on macOS
+include::op-installing-tkn-on-macos.adoc[leveloffset=+1]

--- a/modules/ROOT/pages/op-installing-tkn-on-linux.adoc
+++ b/modules/ROOT/pages/op-installing-tkn-on-linux.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/tkn_cli/installing-tkn.adoc
+
+[id="installing-tkn-on-linux"]
+
+= Installing {op-title} on Linux
+
+== Binary installation
+
+. Get the binary:
++
+----
+# curl -L https://mirror.openshift.com/pub/openshift-v4/clients/tkn/latest/tkn-linux-amd64 -o /usr/local/bin/tkn
+
+----
+. Set up the permissions:
++
+----
+# chmod +x /usr/local/bin/odo
+----
+
+== Tarball installation
+
+=== Linux AMD64
+
+. Get the `tar.gz`:
++
+----
+curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_x86_64.tar.gz
+----
+
+. Extract `tkn` to your PATH:
++
+----
+sudo tar xvzf tkn_0.8.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
+----
+
+=== Linux ARM64
+
+. Get the `tar.gz`:
++
+----
+curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_arm64.tar.gz
+----
+
+. Extract `tkn` to your PATH:
++
+----
+sudo tar xvzf tkn_0.8.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
+----

--- a/modules/ROOT/pages/op-installing-tkn-on-linux.adoc
+++ b/modules/ROOT/pages/op-installing-tkn-on-linux.adoc
@@ -8,13 +8,13 @@
 
 == Binary installation
 
-. Get the binary:
+. Download the binary:
 +
 ----
 # curl -L https://mirror.openshift.com/pub/openshift-v4/clients/tkn/latest/tkn-linux-amd64 -o /usr/local/bin/tkn
 
 ----
-. Set up the permissions:
+. Make the binary file executable:
 +
 ----
 # chmod +x /usr/local/bin/odo
@@ -24,28 +24,31 @@
 
 === Linux AMD64
 
-. Get the `tar.gz`:
+. Download the compressed file:
 +
 ----
-curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_x86_64.tar.gz
+$ curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_x86_64.tar.gz
 ----
 
-. Extract `tkn` to your PATH:
+. Extract the compressed file:
 +
 ----
-sudo tar xvzf tkn_0.8.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
+$ sudo tar xvzf tkn_0.8.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
 ----
+. Place it in a directory that is on your `PATH`.
 
 === Linux ARM64
 
-. Get the `tar.gz`:
+. Download the compressed file:
 +
 ----
-curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_arm64.tar.gz
+$ curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_arm64.tar.gz
 ----
 
-. Extract `tkn` to your PATH:
+. Extract the compressed file:
 +
 ----
-sudo tar xvzf tkn_0.8.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
+$ sudo tar xvzf tkn_0.8.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
 ----
+
+. Place it in a directory that is on your `PATH`.

--- a/modules/ROOT/pages/op-installing-tkn-on-macos.adoc
+++ b/modules/ROOT/pages/op-installing-tkn-on-macos.adoc
@@ -8,7 +8,7 @@
 
 == Binary installation
 
-. Get the binary :
+. Download the binary :
 +
 ----
 # curl -L https://mirror.openshift.com/pub/openshift-v4/clients/tkn/latest/tkn-linux-amd64 -o /usr/local/bin/tkn
@@ -17,21 +17,22 @@
 ----
 # curl -L https://mirror.openshift.com/pub/openshift-v4/clients/tkn/latest/tkn-darwin-amd64 -o /usr/local/bin/tkn
 ----
-. Set up the permissions :
+. Make the binary file executable:
 ----
 # chmod +x /usr/local/bin/tkn
 ----
 
 == Tarball installation
 
-. Get the `tar.gz`:
+. Download the compressed file:
 +
 ----
-curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Darwin_x86_64.tar.gz
+$ curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Darwin_x86_64.tar.gz
 ----
 
-. Extract `tkn` to your PATH:
+. Extract the compressed file:
 +
 ----
-sudo tar xvzf tkn_0.8.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
+$ sudo tar xvzf tkn_0.8.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
 ----
+. Place it in a directory that is on your `PATH`.

--- a/modules/ROOT/pages/op-installing-tkn-on-macos.adoc
+++ b/modules/ROOT/pages/op-installing-tkn-on-macos.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/tkn_cli/installing-tkn.adoc
+
+[id="installing-tkn-on-macos"]
+
+= Installing {op-title} on macOS
+
+== Binary installation
+
+. Get the binary :
++
+----
+# curl -L https://mirror.openshift.com/pub/openshift-v4/clients/tkn/latest/tkn-linux-amd64 -o /usr/local/bin/tkn
+----
++
+----
+# curl -L https://mirror.openshift.com/pub/openshift-v4/clients/tkn/latest/tkn-darwin-amd64 -o /usr/local/bin/tkn
+----
+. Set up the permissions :
+----
+# chmod +x /usr/local/bin/tkn
+----
+
+== Tarball installation
+
+. Get the `tar.gz`:
++
+----
+curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Darwin_x86_64.tar.gz
+----
+
+. Extract `tkn` to your PATH:
++
+----
+sudo tar xvzf tkn_0.8.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
+----

--- a/modules/ROOT/pages/op-installing-tkn-on-windows.adoc
+++ b/modules/ROOT/pages/op-installing-tkn-on-windows.adoc
@@ -9,26 +9,4 @@
 == Binary installation
 
 . Download the latest link:https://mirror.openshift.com/pub/openshift-v4/clients/tkn/latest/tkn-windows-amd64.exe[`tkn.exe`] file.
-. Add the location of your `tkn.exe` to the `PATH` variable.
-
-[discrete]
-== Setting the `PATH` variable for Windows 7/8
-
-The following example demonstrates how to set up a path variable. Your binaries can be located in any location, but this example uses C:\tkn-bin as the location.
-
-. Create a folder at `C:\tkn-bin`.
-. Right click *Start* and click *Control Panel*.
-. Select *System and Security* and then click *System*.
-. From the menu on the left, select the *Advanced systems settings* and click the *Environment Variables* button at the bottom.
-. Select *Path* from the *Variable* section and click *Edit*.
-. Click *New* and type `C:\tkn-bin` into the field or click *Browse* and select the directory, and click *OK*.
-
-[discrete]
-== Setting the `PATH` variable for Windows 10
-
-Edit `Environment Variables` using search:
-
-. Click *Search* and type `env` or `environment`.
-. Select *Edit environment variables for your account*.
-. Select *Path* from the *Variable* section and click *Edit*.
-. Click *New* and type `C:\tkn-bin` into the field or click *Browse* and select the directory, and click *OK*.
+. Add the location of your `tkn.exe` file to the `PATH` environment variable.

--- a/modules/ROOT/pages/op-installing-tkn-on-windows.adoc
+++ b/modules/ROOT/pages/op-installing-tkn-on-windows.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/tkn_cli/installing-tkn.adoc
+
+[id="installing-tkn-on-windows"]
+
+= Installing {op-title} on Windows
+
+== Binary installation
+
+. Download the latest link:https://mirror.openshift.com/pub/openshift-v4/clients/tkn/latest/tkn-windows-amd64.exe[`tkn.exe`] file.
+. Add the location of your `tkn.exe` to the `PATH` variable.
+
+[discrete]
+== Setting the `PATH` variable for Windows 7/8
+
+The following example demonstrates how to set up a path variable. Your binaries can be located in any location, but this example uses C:\tkn-bin as the location.
+
+. Create a folder at `C:\tkn-bin`.
+. Right click *Start* and click *Control Panel*.
+. Select *System and Security* and then click *System*.
+. From the menu on the left, select the *Advanced systems settings* and click the *Environment Variables* button at the bottom.
+. Select *Path* from the *Variable* section and click *Edit*.
+. Click *New* and type `C:\tkn-bin` into the field or click *Browse* and select the directory, and click *OK*.
+
+[discrete]
+== Setting the `PATH` variable for Windows 10
+
+Edit `Environment Variables` using search:
+
+. Click *Search* and type `env` or `environment`.
+. Select *Edit environment variables for your account*.
+. Select *Path* from the *Variable* section and click *Edit*.
+. Click *New* and type `C:\tkn-bin` into the field or click *Browse* and select the directory, and click *OK*.

--- a/modules/ROOT/pages/proc_installing-cli.adoc
+++ b/modules/ROOT/pages/proc_installing-cli.adoc
@@ -10,13 +10,13 @@ In order to interact with Tekton from a terminal, you need to install the Tekton
 . Get the `tar.gz`:
 +
 ----
-curl -LO https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Darwin_x86_64.tar.gz
+curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Darwin_x86_64.tar.gz
 ----
 
 . Extract `tkn` to your PATH:
 +
 ----
-sudo tar xvzf tkn_0.4.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
+sudo tar xvzf tkn_0.8.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
 ----
 
 === For Linux AMD64
@@ -24,13 +24,13 @@ sudo tar xvzf tkn_0.4.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
 . Get the `tar.gz`:
 +
 ----
-curl -LO https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Linux_x86_64.tar.gz
+curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_x86_64.tar.gz
 ----
 
 . Extract `tkn` to your PATH:
 +
 ----
-sudo tar xvzf tkn_0.4.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
+sudo tar xvzf tkn_0.8.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
 ----
 
 === For Linux ARM64
@@ -38,13 +38,13 @@ sudo tar xvzf tkn_0.4.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
 . Get the `tar.gz`:
 +
 ----
-curl -LO https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Linux_arm64.tar.gz
+curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_arm64.tar.gz
 ----
 
 . Extract `tkn` to your PATH:
 +
 ----
-sudo tar xvzf tkn_0.4.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
+sudo tar xvzf tkn_0.8.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
 ----
 
 === For Windows
@@ -52,14 +52,14 @@ sudo tar xvzf tkn_0.4.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
 . Get the `.zip` file:
 +
 ----
-PS C:\Users\Admin\Downloads> curl -Uri https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Windows_x86_64.zip
- -OutFile tkn_0.4.0_Windows_x86_64.zip
+PS C:\Users\Admin\Downloads> curl -Uri https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Windows_x86_64.zip
+ -OutFile tkn_0.8.0_Windows_x86_64.zip
 
 ----
 
 . Extract `tkn` to your path:
 ----
-Expand-Archive -Path <sourcepath>/tkn_0.4.0_Windows_x86_64.zip -DestinationPath <destinationpath>
+Expand-Archive -Path <sourcepath>/tkn_0.8.0_Windows_x86_64.zip -DestinationPath <destinationpath>
 ----
 
 ////

--- a/modules/ROOT/pages/proc_installing-cli.adoc
+++ b/modules/ROOT/pages/proc_installing-cli.adoc
@@ -3,61 +3,67 @@
 
 In order to interact with Tekton from a terminal, you need to install the Tekton CLI (`tkn`).
 
-== Installing from binary
+== Tarball Installation
 
 === For macOS X
 
-. Get the `tar.gz`:
+. Download the compressed file:
 +
 ----
-curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Darwin_x86_64.tar.gz
+$ curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Darwin_x86_64.tar.gz
 ----
 
-. Extract `tkn` to your PATH:
+. Extract the compressed file:
 +
 ----
-sudo tar xvzf tkn_0.8.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
+$ sudo tar xvzf tkn_0.8.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn
 ----
+. Place it in a directory that is on your `PATH`
 
 === For Linux AMD64
 
-. Get the `tar.gz`:
+. Download the compressed file:
 +
 ----
-curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_x86_64.tar.gz
+$ curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_x86_64.tar.gz
 ----
 
-. Extract `tkn` to your PATH:
+. Extract the compressed file:
 +
 ----
-sudo tar xvzf tkn_0.8.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
+$ sudo tar xvzf tkn_0.8.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn
 ----
+
+. Place it in a directory that is on your `PATH`
 
 === For Linux ARM64
 
-. Get the `tar.gz`:
+. Download the compressed file:
 +
 ----
-curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_arm64.tar.gz
+$ curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_arm64.tar.gz
 ----
 
-. Extract `tkn` to your PATH:
+. Extract the compressed file:
 +
 ----
-sudo tar xvzf tkn_0.8.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
+$ sudo tar xvzf tkn_0.8.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn
 ----
+
+. Place it in a directory that is on your `PATH`
 
 === For Windows
 
-. Get the `.zip` file:
+. Download the zip file:
 +
 ----
-PS C:\Users\Admin\Downloads> curl -Uri https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Windows_x86_64.zip
+C:\Users\Admin\Downloads> curl -Uri https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Windows_x86_64.zip
  -OutFile tkn_0.8.0_Windows_x86_64.zip
 
 ----
 
-. Extract `tkn` to your path:
+. Extract the compressed file `tkn.exe` to your `PATH`:
++
 ----
 Expand-Archive -Path <sourcepath>/tkn_0.8.0_Windows_x86_64.zip -DestinationPath <destinationpath>
 ----


### PR DESCRIPTION
tkn installation procedure is now updated to reflect latest tkn CLI paths.

4 new files ( 1 assembly and 3 modules) have been added to reflect the changes that would be going into the OCP repo.  The binary and tar files paths mentioned there will be updated once the productization happens. 