### PR TITLE
Updated references for tkn binary for v0.10

### DIFF
--- a/docs/0.10.5/assembly_cli-reference.html
+++ b/docs/0.10.5/assembly_cli-reference.html
@@ -189,7 +189,7 @@
 <p>Get the <code>tar.gz</code>:</p>
 <div class="listingblock">
 <div class="content">
-<pre>curl -LO https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Darwin_x86_64.tar.gz</pre>
+<pre>curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Darwin_x86_64.tar.gz</pre>
 </div>
 </div>
 </li>
@@ -197,7 +197,7 @@
 <p>Extract <code>tkn</code> to your PATH:</p>
 <div class="listingblock">
 <div class="content">
-<pre>sudo tar xvzf tkn_0.4.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn</pre>
+<pre>sudo tar xvzf tkn_0.8.0_Darwin_x86_64.tar.gz -C /usr/local/bin tkn</pre>
 </div>
 </div>
 </li>
@@ -212,7 +212,7 @@
 <p>Get the <code>tar.gz</code>:</p>
 <div class="listingblock">
 <div class="content">
-<pre>curl -LO https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Linux_x86_64.tar.gz</pre>
+<pre>curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_x86_64.tar.gz</pre>
 </div>
 </div>
 </li>
@@ -220,7 +220,7 @@
 <p>Extract <code>tkn</code> to your PATH:</p>
 <div class="listingblock">
 <div class="content">
-<pre>sudo tar xvzf tkn_0.4.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn</pre>
+<pre>sudo tar xvzf tkn_0.8.0_Linux_x86_64.tar.gz -C /usr/local/bin/ tkn</pre>
 </div>
 </div>
 </li>
@@ -235,7 +235,7 @@
 <p>Get the <code>tar.gz</code>:</p>
 <div class="listingblock">
 <div class="content">
-<pre>curl -LO https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Linux_arm64.tar.gz</pre>
+<pre>curl -LO https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Linux_arm64.tar.gz</pre>
 </div>
 </div>
 </li>
@@ -243,7 +243,7 @@
 <p>Extract <code>tkn</code> to your PATH:</p>
 <div class="listingblock">
 <div class="content">
-<pre>sudo tar xvzf tkn_0.4.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn</pre>
+<pre>sudo tar xvzf tkn_0.8.0_Linux_arm64.tar.gz -C /usr/local/bin/ tkn</pre>
 </div>
 </div>
 </li>
@@ -258,8 +258,8 @@
 <p>Get the <code>.zip</code> file:</p>
 <div class="listingblock">
 <div class="content">
-<pre>PS C:\Users\Admin\Downloads&gt; curl -Uri https://github.com/tektoncd/cli/releases/download/v0.4.0/tkn_0.4.0_Windows_x86_64.zip
- -OutFile tkn_0.4.0_Windows_x86_64.zip</pre>
+<pre>PS C:\Users\Admin\Downloads&gt; curl -Uri https://github.com/tektoncd/cli/releases/download/v0.8.0/tkn_0.8.0_Windows_x86_64.zip
+ -OutFile tkn_0.8.0_Windows_x86_64.zip</pre>
 </div>
 </div>
 </li>
@@ -270,7 +270,7 @@
 </div>
 <div class="listingblock">
 <div class="content">
-<pre>Expand-Archive -Path &lt;sourcepath&gt;/tkn_0.4.0_Windows_x86_64.zip -DestinationPath &lt;destinationpath&gt;</pre>
+<pre>Expand-Archive -Path &lt;sourcepath&gt;/tkn_0.8.0_Windows_x86_64.zip -DestinationPath &lt;destinationpath&gt;</pre>
 </div>
 </div>
 </div>
@@ -298,19 +298,19 @@
 <div class="sect2">
 <h3 id="_utility_commands"><a class="anchor" href="#_utility_commands"></a>Utility commands</h3>
 <div class="sect3">
-<h4 id="_tkn"><a class="anchor" href="#_tkn"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn.md">tkn</a></h4>
+<h4 id="_tkn"><a class="anchor" href="#_tkn"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn.md">tkn</a></h4>
 <div class="paragraph">
 <p>Parent command for Tekton CLI.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_completion"><a class="anchor" href="#_tkn_completion"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_completion.md">tkn completion</a></h4>
+<h4 id="_tkn_completion"><a class="anchor" href="#_tkn_completion"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_completion.md">tkn completion</a></h4>
 <div class="paragraph">
 <p>Prints shell completion scripts.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_version"><a class="anchor" href="#_tkn_version"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_version.md">tkn version</a></h4>
+<h4 id="_tkn_version"><a class="anchor" href="#_tkn_version"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_version.md">tkn version</a></h4>
 <div class="paragraph">
 <p>Prints version information.</p>
 </div>
@@ -319,55 +319,55 @@
 <div class="sect2">
 <h3 id="_managing_and_running_pipelines"><a class="anchor" href="#_managing_and_running_pipelines"></a>Managing and running pipelines</h3>
 <div class="sect3">
-<h4 id="_tkn_pipeline"><a class="anchor" href="#_tkn_pipeline"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_pipeline.md">tkn pipeline</a></h4>
+<h4 id="_tkn_pipeline"><a class="anchor" href="#_tkn_pipeline"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_pipeline.md">tkn pipeline</a></h4>
 <div class="paragraph">
 <p>Manages pipelines.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_pipeline_describe"><a class="anchor" href="#_tkn_pipeline_describe"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_pipeline_describe.md">tkn pipeline describe</a></h4>
+<h4 id="_tkn_pipeline_describe"><a class="anchor" href="#_tkn_pipeline_describe"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_pipeline_describe.md">tkn pipeline describe</a></h4>
 <div class="paragraph">
 <p>Describes a pipeline in a namespace.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_pipeline_list"><a class="anchor" href="#_tkn_pipeline_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_pipeline_list.md">tkn pipeline list</a></h4>
+<h4 id="_tkn_pipeline_list"><a class="anchor" href="#_tkn_pipeline_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_pipeline_list.md">tkn pipeline list</a></h4>
 <div class="paragraph">
 <p>Lists pipelines in a namespace.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_pipeline_logs"><a class="anchor" href="#_tkn_pipeline_logs"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_pipeline_logs.md">tkn pipeline logs</a></h4>
+<h4 id="_tkn_pipeline_logs"><a class="anchor" href="#_tkn_pipeline_logs"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_pipeline_logs.md">tkn pipeline logs</a></h4>
 <div class="paragraph">
 <p>Shows pipeline logs.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_pipeline_start"><a class="anchor" href="#_tkn_pipeline_start"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_pipeline_start.md">tkn pipeline start</a></h4>
+<h4 id="_tkn_pipeline_start"><a class="anchor" href="#_tkn_pipeline_start"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_pipeline_start.md">tkn pipeline start</a></h4>
 <div class="paragraph">
 <p>Starts pipelines.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_pipelinerun"><a class="anchor" href="#_tkn_pipelinerun"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_pipelinerun.md">tkn pipelinerun</a></h4>
+<h4 id="_tkn_pipelinerun"><a class="anchor" href="#_tkn_pipelinerun"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_pipelinerun.md">tkn pipelinerun</a></h4>
 <div class="paragraph">
 <p>Manages pipelineruns.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_pipelinerun_describe"><a class="anchor" href="#_tkn_pipelinerun_describe"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_pipelinerun_describe.md">tkn pipelinerun describe</a></h4>
+<h4 id="_tkn_pipelinerun_describe"><a class="anchor" href="#_tkn_pipelinerun_describe"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_pipelinerun_describe.md">tkn pipelinerun describe</a></h4>
 <div class="paragraph">
 <p>Describes a pipelinerun in a namespace.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_pipelinerun_list"><a class="anchor" href="#_tkn_pipelinerun_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_pipelinerun_list.md">tkn pipelinerun list</a></h4>
+<h4 id="_tkn_pipelinerun_list"><a class="anchor" href="#_tkn_pipelinerun_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_pipelinerun_list.md">tkn pipelinerun list</a></h4>
 <div class="paragraph">
 <p>Lists pipelineruns in a namespace.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_pipelinerun_logs"><a class="anchor" href="#_tkn_pipelinerun_logs"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_pipelinerun_logs.md">tkn pipelinerun logs</a></h4>
+<h4 id="_tkn_pipelinerun_logs"><a class="anchor" href="#_tkn_pipelinerun_logs"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_pipelinerun_logs.md">tkn pipelinerun logs</a></h4>
 <div class="paragraph">
 <p>Shows pipelinerun logs.</p>
 </div>
@@ -376,19 +376,19 @@
 <div class="sect2">
 <h3 id="_managing_pipeline_resources"><a class="anchor" href="#_managing_pipeline_resources"></a>Managing pipeline resources</h3>
 <div class="sect3">
-<h4 id="_tkn_resource"><a class="anchor" href="#_tkn_resource"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_resource.md">tkn resource</a></h4>
+<h4 id="_tkn_resource"><a class="anchor" href="#_tkn_resource"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_resource.md">tkn resource</a></h4>
 <div class="paragraph">
 <p>Manages pipeline resources.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_resource_describe"><a class="anchor" href="#_tkn_resource_describe"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_resource_describe.md">tkn resource describe</a></h4>
+<h4 id="_tkn_resource_describe"><a class="anchor" href="#_tkn_resource_describe"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_resource_describe.md">tkn resource describe</a></h4>
 <div class="paragraph">
 <p>Describes a pipeline resource in a namespace.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_resource_list"><a class="anchor" href="#_tkn_resource_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_resource_list.md">tkn resource list</a></h4>
+<h4 id="_tkn_resource_list"><a class="anchor" href="#_tkn_resource_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_resource_list.md">tkn resource list</a></h4>
 <div class="paragraph">
 <p>Lists pipeline resources in a namespace.</p>
 </div>
@@ -397,31 +397,31 @@
 <div class="sect2">
 <h3 id="_managing_and_running_tasks"><a class="anchor" href="#_managing_and_running_tasks"></a>Managing and running tasks</h3>
 <div class="sect3">
-<h4 id="_tkn_task"><a class="anchor" href="#_tkn_task"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_task.md">tkn task</a></h4>
+<h4 id="_tkn_task"><a class="anchor" href="#_tkn_task"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_task.md">tkn task</a></h4>
 <div class="paragraph">
 <p>Manages tasks.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_task_list"><a class="anchor" href="#_tkn_task_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_task_list.md">tkn task list</a></h4>
+<h4 id="_tkn_task_list"><a class="anchor" href="#_tkn_task_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_task_list.md">tkn task list</a></h4>
 <div class="paragraph">
 <p>Lists tasks in a namespace.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_taskrun"><a class="anchor" href="#_tkn_taskrun"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_taskrun.md">tkn taskrun</a></h4>
+<h4 id="_tkn_taskrun"><a class="anchor" href="#_tkn_taskrun"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_taskrun.md">tkn taskrun</a></h4>
 <div class="paragraph">
 <p>Manages taskruns.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_taskrun_list"><a class="anchor" href="#_tkn_taskrun_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_taskrun_list.md">tkn taskrun list</a></h4>
+<h4 id="_tkn_taskrun_list"><a class="anchor" href="#_tkn_taskrun_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_taskrun_list.md">tkn taskrun list</a></h4>
 <div class="paragraph">
 <p>Lists taskruns in a namespace.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_taskrun_logs"><a class="anchor" href="#_tkn_taskrun_logs"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_taskrun_logs.md">tkn taskrun logs</a></h4>
+<h4 id="_tkn_taskrun_logs"><a class="anchor" href="#_tkn_taskrun_logs"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_taskrun_logs.md">tkn taskrun logs</a></h4>
 <div class="paragraph">
 <p>Shows taskruns logs.</p>
 </div>
@@ -430,13 +430,13 @@
 <div class="sect2">
 <h3 id="_managing_clusters"><a class="anchor" href="#_managing_clusters"></a>Managing clusters</h3>
 <div class="sect3">
-<h4 id="_tkn_clustertask"><a class="anchor" href="#_tkn_clustertask"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_clustertask.md">tkn clustertask</a></h4>
+<h4 id="_tkn_clustertask"><a class="anchor" href="#_tkn_clustertask"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_clustertask.md">tkn clustertask</a></h4>
 <div class="paragraph">
 <p>Manages clustertasks.</p>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_tkn_clustertask_list"><a class="anchor" href="#_tkn_clustertask_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.4.0/docs/cmd/tkn_clustertask_list.md">tkn clustertask list</a></h4>
+<h4 id="_tkn_clustertask_list"><a class="anchor" href="#_tkn_clustertask_list"></a><a href="https://github.com/tektoncd/cli/blob/release-v0.8.0/docs/cmd/tkn_clustertask_list.md">tkn clustertask list</a></h4>
 <div class="paragraph">
 <p>Lists clustertasks in a namespace.</p>
 </div>


### PR DESCRIPTION
The referenced `tkn` binary is `v0.4.0` which is not compatible with the `v0.10` version of pipelines.

Refer to https://github.com/tektoncd/cli/issues/879 to see the issue and the outcome which motivated this PR.